### PR TITLE
Add Package-Requires header

### DIFF
--- a/term+key-intercept.el
+++ b/term+key-intercept.el
@@ -4,6 +4,7 @@
 ;; URL: http://github.com/tarao/term+-el
 ;; Version: 0.1
 ;; Keywords: terminal, emulation
+;; Package-Requires: ((term+ "0.1") (key-intercept "0.1"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
For the following MELPA registration, we need to add a `Package-Requires` header to `term+key-intercept.el`.

https://github.com/milkypostman/melpa/pull/1469
