### PR TITLE
Update url of key-intercept-el submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/key-intercept-el"]
 	path = lib/key-intercept-el
-	url = git://github.com/tarao/key-intercept-el.git
+	url = https://github.com/tarao/key-intercept-el.git


### PR DESCRIPTION
Github no longer supports git:// urls.

This prevents the package from being build on Melpa because currently the tool used to do so (`package-build.el`) insists on checking out all submodules, which here fails.